### PR TITLE
Fix: Fix adding widgets on API 34+ by adding optional OptionsBundle

### DIFF
--- a/app/src/main/java/com/stario/launcher/sheet/widgets/dialog/WidgetsDialog.java
+++ b/app/src/main/java/com/stario/launcher/sheet/widgets/dialog/WidgetsDialog.java
@@ -18,6 +18,7 @@
 package com.stario.launcher.sheet.widgets.dialog;
 
 import android.app.Activity;
+import android.app.ActivityOptions;
 import android.appwidget.AppWidgetHostView;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProviderInfo;
@@ -27,6 +28,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -293,7 +295,7 @@ public class WidgetsDialog extends SheetDialogFragment {
             } else {
                 getWidgetHost().startAppWidgetConfigureActivityForResult(activity, identifier,
                         Intent.FLAG_ACTIVITY_RETAIN_IN_RECENTS | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED,
-                        CONFIGURATION_CODE, null);
+                        CONFIGURATION_CODE, getActivityOptionsBundle());
             }
         } catch (ActivityNotFoundException exception) {
             activity.removeOnActivityResultListener(CONFIGURATION_CODE);
@@ -405,5 +407,18 @@ public class WidgetsDialog extends SheetDialogFragment {
         }
 
         super.onStop();
+    }
+
+    private static Bundle getActivityOptionsBundle() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ActivityOptions activityOptions = ActivityOptions.makeBasic();
+            activityOptions.setPendingIntentBackgroundActivityStartMode(ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED);
+            return activityOptions.toBundle();
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+            ActivityOptions activityOptions = ActivityOptions.makeBasic();
+            activityOptions.setPendingIntentBackgroundActivityStartMode(ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOW_IF_VISIBLE);
+            return activityOptions.toBundle();
+        } else
+            return null;
     }
 }


### PR DESCRIPTION
So, this fixes the issue that widgets can't be added to Android devices with API 34 and up by adding `ActivityOptions` to `startAppWidgetConfigureActivityForResult` in the `configureWidget` function.

I basically just used [this](https://stackoverflow.com/a/79287848) StackOverflow answer.

Test device used is a OnePlus 9 Pro running android 14 in case it's relevant.
